### PR TITLE
GUI: Properly update screen after mouse movement

### DIFF
--- a/backends/graphics/opengl/opengl-graphics.cpp
+++ b/backends/graphics/opengl/opengl-graphics.cpp
@@ -955,17 +955,13 @@ void OpenGLGraphicsManager::handleResizeImpl(const int width, const int height, 
 	overlayWidth = MAX<uint>(overlayWidth, 256);
 	overlayHeight = MAX<uint>(overlayHeight, 200);
 
-	// HACK: Reduce the size of the overlay on high DPI screens.
-	overlayWidth = fracToInt(overlayWidth * (intToFrac(90) / xdpi));
-	overlayHeight = fracToInt(overlayHeight * (intToFrac(90) / ydpi));
-
 	if (!_overlay || _overlay->getFormat() != _defaultFormatAlpha) {
 		delete _overlay;
 		_overlay = nullptr;
 
 		_overlay = createSurface(_defaultFormatAlpha);
 		assert(_overlay);
-		// We should NOT always filter the overlay with GL_LINEAR. 
+		// We should NOT always filter the overlay with GL_LINEAR.
 		// In previous versions we always did use GL_LINEAR to assure the UI
 		// would be readable in case it needed to be scaled -- it would not affect it otherwise.
 		// However in modern devices due to larger screen size the UI display looks blurry

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -249,6 +249,8 @@ bool OpenGLSdlGraphicsManager::getFeatureState(OSystem::Feature f) const {
 			return _wantsFullScreen;
 		}
 #endif
+	case OSystem::kFeatureHiDPI:
+		return getGraphicsModeScale(0) == 2;
 
 	default:
 		return OpenGLGraphicsManager::getFeatureState(f);

--- a/backends/graphics/openglsdl/openglsdl-graphics.cpp
+++ b/backends/graphics/openglsdl/openglsdl-graphics.cpp
@@ -439,7 +439,7 @@ bool OpenGLSdlGraphicsManager::setupMode(uint width, uint height) {
 		width  = _desiredFullscreenWidth;
 		height = _desiredFullscreenHeight;
 
-		flags |= SDL_WINDOW_FULLSCREEN;
+		flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 	}
 
 	// Request a OpenGL (ES) context we can use.

--- a/backends/graphics/openglsdl/openglsdl-graphics.h
+++ b/backends/graphics/openglsdl/openglsdl-graphics.h
@@ -60,7 +60,11 @@ protected:
 
 	virtual bool saveScreenshot(const Common::String &filename) const override;
 
-	virtual int getGraphicsModeScale(int mode) const override { return 1; }
+	virtual int getGraphicsModeScale(int mode) const override {
+		uint scale;
+		getDpiScalingFactor(&scale);
+		return scale;
+	}
 
 private:
 	bool setupMode(uint width, uint height);

--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -200,6 +200,11 @@ bool SdlGraphicsManager::notifyMousePosition(Common::Point &mouse) {
 	mouse.y = CLIP<int16>(mouse.y, 0, _windowHeight - 1);
 
 	int showCursor = SDL_DISABLE;
+	// DPI aware scaling to mouse position
+	uint scale;
+	getDpiScalingFactor(&scale);
+	mouse.x *= scale;
+	mouse.y *= scale;
 	bool valid = true;
 	if (_activeArea.drawRect.contains(mouse)) {
 		_cursorLastInActiveArea = true;
@@ -258,6 +263,9 @@ bool SdlGraphicsManager::createOrUpdateWindow(int width, int height, const Uint3
 	if (!_window) {
 		return false;
 	}
+
+	// width *=3;
+	// height *=3;
 
 	// We only update the actual window when flags change (which usually means
 	// fullscreen mode is entered/exited), when updates are forced so that we

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -169,7 +169,8 @@ protected:
 	void getWindowSizeFromSdl(int *width, int *height) const {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 		assert(_window);
-		SDL_GetWindowSize(_window->getSDLWindow(), width, height);
+		SDL_GL_GetDrawableSize(_window->getSDLWindow(), width, height);
+		// SDL_GetWindowSize(_window->getSDLWindow(), width, height);
 #else
 		assert(_hwScreen);
 
@@ -181,6 +182,57 @@ protected:
 			*height = _hwScreen->h;
 		}
 #endif
+	}
+	/**
+	 * Gets the display index that the ScummVM window is on
+	 */
+	void getWindowDisplayIndexFromSdl(int *index) const {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+		assert(_window);
+		*index = SDL_GetWindowDisplayIndex(_window->getSDLWindow());
+#else
+		*index = 0;
+#endif
+	}
+
+	void getDisplayDpiFromSdl(float *dpi, float *defaultDpi) const {
+		const float systemDpi =
+#ifdef __APPLE__
+		72.0f;
+#elif defined(_WIN32)
+		96.0f;
+#else
+		90.0f; // ScummVM default
+#endif
+		if (defaultDpi)
+			*defaultDpi = systemDpi;
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+		int displayIndex = 0;
+		getWindowDisplayIndexFromSdl(&displayIndex);
+
+		if (SDL_GetDisplayDPI(displayIndex, NULL, dpi, NULL) != 0) {
+		if (dpi)
+			*dpi = systemDpi;
+		}
+#else
+		*dpi = systemDpi;
+#endif
+	}
+
+	/**
+	 * Returns the scaling mode based on the display DPI
+	 */
+	void getDpiScalingFactor(uint *scale) const {
+		float dpi, defaultDpi, ratio;
+
+		getDisplayDpiFromSdl(&dpi, &defaultDpi);
+		debug(4, "dpi: %g default: %g", dpi, defaultDpi);
+		ratio = dpi / defaultDpi;
+		if (ratio >= 2.0f) {
+			*scale = 2;
+		} else {
+			*scale = 1;
+		}
 	}
 
 	virtual void setSystemMousePosition(const int x, const int y) override;

--- a/common/system.h
+++ b/common/system.h
@@ -335,6 +335,11 @@ public:
 		kFeatureFilteringMode,
 
 		/**
+		 * Indicates that GUI runs in HiDPI mode
+		 */
+		kFeatureHiDPI,
+
+		/**
 		 * Indicate if stretch modes are supported by the backend.
 		 */
 		kFeatureStretchMode,

--- a/dists/macosx/Info.plist
+++ b/dists/macosx/Info.plist
@@ -76,5 +76,7 @@
 	<string>ScummVM saves and loads savegames in the Documents folder by default.</string>
 	<key>SUPublicDSAKeyFile</key>
 	<string>dsa_pub.pem</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
 </dict>
 </plist>

--- a/dists/macosx/Info.plist.in
+++ b/dists/macosx/Info.plist.in
@@ -76,5 +76,7 @@
 	<string>ScummVM saves and loads savegames in the Documents folder by default.</string>
 	<key>SUPublicDSAKeyFile</key>
 	<string>dsa_pub.pem</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
 </dict>
 </plist>

--- a/engines/dialogs.cpp
+++ b/engines/dialogs.cpp
@@ -89,7 +89,7 @@ MainMenuDialog::MainMenuDialog(Engine *engine)
 
 	new GUI::ButtonWidget(this, "GlobalMenu.About", _("~A~bout"), Common::U32String(""), kAboutCmd);
 
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getBaseWidth() > 320)
 		_returnToLauncherButton = new GUI::ButtonWidget(this, "GlobalMenu.ReturnToLauncher", _("~R~eturn to Launcher"), Common::U32String(""), kLauncherCmd);
 	else
 		_returnToLauncherButton = new GUI::ButtonWidget(this, "GlobalMenu.ReturnToLauncher", _c("~R~eturn to Launcher", "lowres"), Common::U32String(""), kLauncherCmd);
@@ -165,7 +165,7 @@ void MainMenuDialog::reflowLayout() {
 	// Update labels when it might be needed
 	// FIXME: it might be better to declare GUI::StaticTextWidget::setLabel() virtual
 	// and to reimplement it in GUI::ButtonWidget to handle the hotkey.
-	if (g_system->getOverlayWidth() > 320)
+	if (g_gui.getBaseWidth() > 320)
 		_returnToLauncherButton->setLabel(_returnToLauncherButton->cleanupHotkey(_("~R~eturn to Launcher")));
 	else
 		_returnToLauncherButton->setLabel(_returnToLauncherButton->cleanupHotkey(_c("~R~eturn to Launcher", "lowres")));

--- a/gui/ThemeEngine.cpp
+++ b/gui/ThemeEngine.cpp
@@ -374,7 +374,7 @@ void ThemeEngine::clearAll() {
 	}
 }
 
-void ThemeEngine::refresh() {
+void ThemeEngine::refresh(int16 baseWidth, int16 baseHeight) {
 
 	// Flush all bitmaps if the overlay pixel format changed.
 	if (_overlayFormat != _system->getOverlayFormat()) {
@@ -396,6 +396,8 @@ void ThemeEngine::refresh() {
 		}
 		_abitmaps.clear();
 	}
+
+	_parser->setBaseResolution(baseWidth, baseHeight);
 
 	init();
 

--- a/gui/ThemeEngine.cpp
+++ b/gui/ThemeEngine.cpp
@@ -374,7 +374,7 @@ void ThemeEngine::clearAll() {
 	}
 }
 
-void ThemeEngine::refresh(int16 baseWidth, int16 baseHeight) {
+void ThemeEngine::refresh(int16 baseWidth, int16 baseHeight, float scaleFactor) {
 
 	// Flush all bitmaps if the overlay pixel format changed.
 	if (_overlayFormat != _system->getOverlayFormat()) {
@@ -397,7 +397,7 @@ void ThemeEngine::refresh(int16 baseWidth, int16 baseHeight) {
 		_abitmaps.clear();
 	}
 
-	_parser->setBaseResolution(baseWidth, baseHeight);
+	_parser->setBaseResolution(baseWidth, baseHeight, scaleFactor);
 
 	init();
 

--- a/gui/ThemeEngine.cpp
+++ b/gui/ThemeEngine.cpp
@@ -189,7 +189,7 @@ ThemeEngine::ThemeEngine(Common::String id, GraphicsMode mode) :
 	_system(nullptr), _vectorRenderer(nullptr),
 	_layerToDraw(kDrawLayerBackground), _bytesPerPixel(0),  _graphicsMode(kGfxDisabled),
 	_font(nullptr), _initOk(false), _themeOk(false), _enabled(false), _themeFiles(),
-	_cursor(nullptr) {
+	_cursor(nullptr), _scaleFactor(1.0f) {
 
 	_system = g_system;
 	_parser = new ThemeParser(this);
@@ -308,8 +308,13 @@ const char *ThemeEngine::findModeConfigName(GraphicsMode mode) {
 }
 
 
+void ThemeEngine::setBaseResolution(int w, int h, float s) {
+	_baseWidth = w;
+	_baseHeight = h;
+	_scaleFactor = s;
 
-
+	_parser->setBaseResolution(w, h, s);
+}
 
 /**********************************************************
  * Theme setup/initialization
@@ -374,7 +379,7 @@ void ThemeEngine::clearAll() {
 	}
 }
 
-void ThemeEngine::refresh(int16 baseWidth, int16 baseHeight, float scaleFactor) {
+void ThemeEngine::refresh() {
 
 	// Flush all bitmaps if the overlay pixel format changed.
 	if (_overlayFormat != _system->getOverlayFormat()) {
@@ -396,8 +401,6 @@ void ThemeEngine::refresh(int16 baseWidth, int16 baseHeight, float scaleFactor) 
 		}
 		_abitmaps.clear();
 	}
-
-	_parser->setBaseResolution(baseWidth, baseHeight, scaleFactor);
 
 	init();
 
@@ -668,6 +671,14 @@ bool ThemeEngine::addBitmap(const Common::String &filename) {
 			surf = srcSurface->convertTo(_overlayFormat);
 	}
 
+	if (_scaleFactor != 1.0) {
+		Graphics::Surface *tmp2 = surf->scale(surf->w * _scaleFactor, surf->h * _scaleFactor, false);
+
+		surf->free();
+		delete surf;
+
+		surf = tmp2;
+	}
 	// Store the surface into our hashmap (attention, may store NULL entries!)
 	_bitmaps[filename] = surf;
 

--- a/gui/ThemeEngine.h
+++ b/gui/ThemeEngine.h
@@ -318,10 +318,11 @@ public:
 	/** Default destructor */
 	~ThemeEngine();
 
+	void setBaseResolution(int w, int h, float s);
 	bool init();
 	void clearAll();
 
-	void refresh(int16 baseWidth, int16 baseHeight, float scaleFactor);
+	void refresh();
 	void enable();
 
 	void showCursor();
@@ -725,6 +726,9 @@ protected:
 
 	/** Current graphics mode */
 	GraphicsMode _graphicsMode;
+
+	int16 _baseWidth, _baseHeight;
+	float _scaleFactor;
 
 	/** Font info. */
 	const Graphics::Font *_font;

--- a/gui/ThemeEngine.h
+++ b/gui/ThemeEngine.h
@@ -321,7 +321,7 @@ public:
 	bool init();
 	void clearAll();
 
-	void refresh(int16 baseWidth, int16 baseHeight);
+	void refresh(int16 baseWidth, int16 baseHeight, float scaleFactor);
 	void enable();
 
 	void showCursor();

--- a/gui/ThemeEngine.h
+++ b/gui/ThemeEngine.h
@@ -321,7 +321,7 @@ public:
 	bool init();
 	void clearAll();
 
-	void refresh();
+	void refresh(int16 baseWidth, int16 baseHeight);
 	void enable();
 
 	void showCursor();

--- a/gui/ThemeLayout.cpp
+++ b/gui/ThemeLayout.cpp
@@ -276,10 +276,10 @@ void ThemeLayoutMain::reflowLayout(Widget *widgetChain) {
 			_h = _children[0]->getHeight();
 
 		if (_y == -1)
-			_y = (g_gui.getBaseHeight() >> 1) - (_h >> 1);
+			_y = (g_system->getOverlayHeight() >> 1) - (_h >> 1);
 
 		if (_x == -1)
-			_x = (g_gui.getBaseWidth() >> 1) - (_w >> 1);
+			_x = (g_system->getOverlayWidth() >> 1) - (_w >> 1);
 	}
 }
 

--- a/gui/ThemeLayout.cpp
+++ b/gui/ThemeLayout.cpp
@@ -225,13 +225,13 @@ void ThemeLayoutMain::reflowLayout(Widget *widgetChain) {
 	if (_overlays == "screen") {
 		_x = 0;
 		_y = 0;
-		_w = g_gui.getBaseWidth();
-		_h = g_gui.getBaseHeight();
+		_w = g_gui.getBaseWidth() * g_gui.getScaleFactor();
+		_h = g_gui.getBaseHeight() * g_gui.getScaleFactor();
 	} else if (_overlays == "screen_center") {
 		_x = -1;
 		_y = -1;
-		_w = _defaultW > 0 ? MIN(_defaultW, g_gui.getBaseWidth()) : -1;
-		_h = _defaultH > 0 ? MIN(_defaultH, g_gui.getBaseHeight()) : -1;
+		_w = _defaultW > 0 ? MIN(_defaultW, g_gui.getBaseWidth()) * g_gui.getScaleFactor() : -1;
+		_h = _defaultH > 0 ? MIN(_defaultH, g_gui.getBaseHeight()) * g_gui.getScaleFactor() : -1;
 	} else {
 		if (!g_gui.xmlEval()->getWidgetData(_overlays, _x, _y, _w, _h)) {
 			warning("Unable to retrieve overlayed dialog position %s", _overlays.c_str());
@@ -239,10 +239,10 @@ void ThemeLayoutMain::reflowLayout(Widget *widgetChain) {
 
 		if (_w == -1 || _h == -1) {
 			warning("The overlayed dialog %s has not been sized, using a default size for %s", _overlays.c_str(), _name.c_str());
-			_x = g_gui.getBaseWidth()      / 10;
-			_y = g_gui.getBaseHeight()     / 10;
-			_w = g_gui.getBaseWidth()  * 8 / 10;
-			_h = g_gui.getBaseHeight() * 8 / 10;
+			_x = g_gui.getBaseWidth()      / 10 * g_gui.getScaleFactor();
+			_y = g_gui.getBaseHeight()     / 10 * g_gui.getScaleFactor();
+			_w = g_gui.getBaseWidth()  * 8 / 10 * g_gui.getScaleFactor();
+			_h = g_gui.getBaseHeight() * 8 / 10 * g_gui.getScaleFactor();
 		}
 	}
 
@@ -254,15 +254,15 @@ void ThemeLayoutMain::reflowLayout(Widget *widgetChain) {
 				add them here and in Widget::draw() to enable RTL support for that particular dialog
 			*/
 			int oldX = _x;
-			_x = g_gui.getBaseWidth() - _w - _x;
+			_x = g_gui.getBaseWidth() * g_gui.getScaleFactor() - _w - _x;
 			g_gui.setDialogPaddings(oldX, _x);
 		}
 	}
 
-	if (_x >= 0) _x += _inset;
-	if (_y >= 0) _y += _inset;
-	if (_w >= 0) _w -= 2 * _inset;
-	if (_h >= 0) _h -= 2 * _inset;
+	if (_x >= 0) _x += _inset * g_gui.getScaleFactor();
+	if (_y >= 0) _y += _inset * g_gui.getScaleFactor();
+	if (_w >= 0) _w -= 2 * _inset * g_gui.getScaleFactor();
+	if (_h >= 0) _h -= 2 * _inset * g_gui.getScaleFactor();
 
 	if (_children.size()) {
 		_children[0]->setWidth(_w);

--- a/gui/ThemeLayout.cpp
+++ b/gui/ThemeLayout.cpp
@@ -225,13 +225,13 @@ void ThemeLayoutMain::reflowLayout(Widget *widgetChain) {
 	if (_overlays == "screen") {
 		_x = 0;
 		_y = 0;
-		_w = g_system->getOverlayWidth();
-		_h = g_system->getOverlayHeight();
+		_w = g_gui.getBaseWidth();
+		_h = g_gui.getBaseHeight();
 	} else if (_overlays == "screen_center") {
 		_x = -1;
 		_y = -1;
-		_w = _defaultW > 0 ? MIN(_defaultW, g_system->getOverlayWidth()) : -1;
-		_h = _defaultH > 0 ? MIN(_defaultH, g_system->getOverlayHeight()) : -1;
+		_w = _defaultW > 0 ? MIN(_defaultW, g_gui.getBaseWidth()) : -1;
+		_h = _defaultH > 0 ? MIN(_defaultH, g_gui.getBaseHeight()) : -1;
 	} else {
 		if (!g_gui.xmlEval()->getWidgetData(_overlays, _x, _y, _w, _h)) {
 			warning("Unable to retrieve overlayed dialog position %s", _overlays.c_str());
@@ -239,10 +239,10 @@ void ThemeLayoutMain::reflowLayout(Widget *widgetChain) {
 
 		if (_w == -1 || _h == -1) {
 			warning("The overlayed dialog %s has not been sized, using a default size for %s", _overlays.c_str(), _name.c_str());
-			_x = g_system->getOverlayWidth()      / 10;
-			_y = g_system->getOverlayHeight()     / 10;
-			_w = g_system->getOverlayWidth()  * 8 / 10;
-			_h = g_system->getOverlayHeight() * 8 / 10;
+			_x = g_gui.getBaseWidth()      / 10;
+			_y = g_gui.getBaseHeight()     / 10;
+			_w = g_gui.getBaseWidth()  * 8 / 10;
+			_h = g_gui.getBaseHeight() * 8 / 10;
 		}
 	}
 
@@ -254,7 +254,7 @@ void ThemeLayoutMain::reflowLayout(Widget *widgetChain) {
 				add them here and in Widget::draw() to enable RTL support for that particular dialog
 			*/
 			int oldX = _x;
-			_x = g_system->getOverlayWidth() - _w - _x;
+			_x = g_gui.getBaseWidth() - _w - _x;
 			g_gui.setDialogPaddings(oldX, _x);
 		}
 	}
@@ -276,10 +276,10 @@ void ThemeLayoutMain::reflowLayout(Widget *widgetChain) {
 			_h = _children[0]->getHeight();
 
 		if (_y == -1)
-			_y = (g_system->getOverlayHeight() >> 1) - (_h >> 1);
+			_y = (g_gui.getBaseHeight() >> 1) - (_h >> 1);
 
 		if (_x == -1)
-			_x = (g_system->getOverlayWidth() >> 1) - (_w >> 1);
+			_x = (g_gui.getBaseWidth() >> 1) - (_w >> 1);
 	}
 }
 

--- a/gui/ThemeParser.cpp
+++ b/gui/ThemeParser.cpp
@@ -111,6 +111,8 @@ ThemeParser::ThemeParser(ThemeEngine *parent) : XMLParser() {
 	_defaultStepGlobal = defaultDrawStep();
 	_defaultStepLocal = nullptr;
 	_theme = parent;
+
+	_baseWidth = _baseHeight = 0;
 }
 
 ThemeParser::~ThemeParser() {
@@ -904,7 +906,7 @@ bool ThemeParser::parseCommonLayoutProps(ParserNode *node, const Common::String 
 					return false;
 
 				if (wtoken.lastChar() == '%')
-					width = g_system->getOverlayWidth() * width / 100;
+					width = _baseWidth * width / 100;
 			}
 
 			htoken = tokenizer.nextToken();
@@ -918,7 +920,7 @@ bool ThemeParser::parseCommonLayoutProps(ParserNode *node, const Common::String 
 					return false;
 
 				if (htoken.lastChar() == '%')
-					height = g_system->getOverlayHeight() * height / 100;
+					height = _baseHeight * height / 100;
 			}
 
 			if (!tokenizer.empty())
@@ -944,7 +946,7 @@ bool ThemeParser::parseCommonLayoutProps(ParserNode *node, const Common::String 
 				if (!_theme->getEvaluator()->hasVar(var + "Width"))
 					return false;
 
-				x = (g_system->getOverlayWidth() / 2) - (_theme->getEvaluator()->getVar(var + "Width") / 2);
+				x = (_baseWidth / 2) - (_theme->getEvaluator()->getVar(var + "Width") / 2);
 
 			} else if (_theme->getEvaluator()->hasVar(xpos)) {
 				x = _theme->getEvaluator()->getVar(xpos);
@@ -955,7 +957,7 @@ bool ThemeParser::parseCommonLayoutProps(ParserNode *node, const Common::String 
 					return false;
 
 				if (xpos.lastChar() == 'r')
-					x = g_system->getOverlayWidth() - x;
+					x = _baseWidth - x;
 			}
 
 			ypos = tokenizer.nextToken();
@@ -964,7 +966,7 @@ bool ThemeParser::parseCommonLayoutProps(ParserNode *node, const Common::String 
 				if (!_theme->getEvaluator()->hasVar(var + "Height"))
 					return false;
 
-				y = (g_system->getOverlayHeight() / 2) - (_theme->getEvaluator()->getVar(var + "Height") / 2);
+				y = (_baseHeight / 2) - (_theme->getEvaluator()->getVar(var + "Height") / 2);
 
 			} else if (_theme->getEvaluator()->hasVar(ypos)) {
 				y = _theme->getEvaluator()->getVar(ypos);
@@ -975,7 +977,7 @@ bool ThemeParser::parseCommonLayoutProps(ParserNode *node, const Common::String 
 					return false;
 
 				if (ypos.lastChar() == 'b')
-					y = g_system->getOverlayHeight() - y;
+					y = _baseHeight - y;
 			}
 
 			if (!tokenizer.empty())
@@ -1029,9 +1031,9 @@ bool ThemeParser::resolutionCheck(const Common::String &resolution) {
 		}
 
 		if (cur[0] == 'x') {
-			val = g_system->getOverlayWidth();
+			val = _baseWidth;
 		} else if (cur[0] == 'y') {
-			val = g_system->getOverlayHeight();
+			val = _baseHeight;
 		} else {
 			warning("Error parsing theme 'resolution' token '%s'", resolution.c_str());
 			return false;

--- a/gui/ThemeParser.h
+++ b/gui/ThemeParser.h
@@ -36,9 +36,10 @@ public:
 
 	~ThemeParser() override;
 
-	void setBaseResolution(int w, int h) {
+	void setBaseResolution(int w, int h, float s) {
 		_baseWidth = w;
 		_baseHeight = h;
+		_scaleFactor = s;
 	}
 
 	bool getPaletteColor(const Common::String &name, int &r, int &g, int &b) {
@@ -272,6 +273,7 @@ protected:
 	Graphics::DrawStep *_defaultStepLocal;
 
 	int16 _baseWidth, _baseHeight;
+	float _scaleFactor;
 
 	struct PaletteColor {
 		uint8 r, g, b;

--- a/gui/ThemeParser.h
+++ b/gui/ThemeParser.h
@@ -36,6 +36,11 @@ public:
 
 	~ThemeParser() override;
 
+	void setBaseResolution(int w, int h) {
+		_baseWidth = w;
+		_baseHeight = h;
+	}
+
 	bool getPaletteColor(const Common::String &name, int &r, int &g, int &b) {
 		if (!_palette.contains(name))
 			return false;
@@ -265,6 +270,8 @@ protected:
 
 	Graphics::DrawStep *_defaultStepGlobal;
 	Graphics::DrawStep *_defaultStepLocal;
+
+	int16 _baseWidth, _baseHeight;
 
 	struct PaletteColor {
 		uint8 r, g, b;

--- a/gui/Tooltip.cpp
+++ b/gui/Tooltip.cpp
@@ -42,9 +42,9 @@ void Tooltip::setup(Dialog *parent, Widget *widget, int x, int y) {
 
 	_parent = parent;
 
-	_maxWidth = g_gui.xmlEval()->getVar("Globals.Tooltip.MaxWidth", 100);
-	_xdelta = g_gui.xmlEval()->getVar("Globals.Tooltip.XDelta", 0);
-	_ydelta = g_gui.xmlEval()->getVar("Globals.Tooltip.YDelta", 0);
+	_maxWidth = g_gui.xmlEval()->getVar("Globals.Tooltip.MaxWidth", 100) * g_gui.getScaleFactor();
+	_xdelta = g_gui.xmlEval()->getVar("Globals.Tooltip.XDelta", 0) * g_gui.getScaleFactor();
+	_ydelta = g_gui.xmlEval()->getVar("Globals.Tooltip.YDelta", 0) * g_gui.getScaleFactor();
 
 	const Graphics::Font *tooltipFont = g_gui.theme()->getFont(ThemeEngine::kFontStyleTooltip);
 
@@ -52,8 +52,8 @@ void Tooltip::setup(Dialog *parent, Widget *widget, int x, int y) {
 	_w = tooltipFont->wordWrapText(widget->getTooltip(), _maxWidth - 4, _wrappedLines) + 4;
 	_h = (tooltipFont->getFontHeight() + 2) * _wrappedLines.size() + 4;
 
-	_x = MIN<int16>(parent->_x + x + _xdelta, g_gui.getBaseWidth() - _w - 3);
-	_y = MIN<int16>(parent->_y + y + _ydelta, g_gui.getBaseHeight() - _h - 3);
+	_x = MIN<int16>(parent->_x + x + _xdelta, g_system->getOverlayWidth() - _w - 3);
+	_y = MIN<int16>(parent->_y + y + _ydelta, g_system->getOverlayHeight() - _h - 3);
 
 	if (g_gui.useRTL())
 		_x = g_system->getOverlayWidth() - _w - _x + g_gui.getOverlayOffset();

--- a/gui/Tooltip.cpp
+++ b/gui/Tooltip.cpp
@@ -52,8 +52,8 @@ void Tooltip::setup(Dialog *parent, Widget *widget, int x, int y) {
 	_w = tooltipFont->wordWrapText(widget->getTooltip(), _maxWidth - 4, _wrappedLines) + 4;
 	_h = (tooltipFont->getFontHeight() + 2) * _wrappedLines.size() + 4;
 
-	_x = MIN<int16>(parent->_x + x + _xdelta, g_gui.getWidth() - _w - 3);
-	_y = MIN<int16>(parent->_y + y + _ydelta, g_gui.getHeight() - _h - 3);
+	_x = MIN<int16>(parent->_x + x + _xdelta, g_gui.getBaseWidth() - _w - 3);
+	_y = MIN<int16>(parent->_y + y + _ydelta, g_gui.getBaseHeight() - _h - 3);
 
 	if (g_gui.useRTL())
 		_x = g_system->getOverlayWidth() - _w - _x + g_gui.getOverlayOffset();

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -64,8 +64,6 @@ GuiManager::GuiManager() : _redrawStatus(kRedrawDisabled), _stateIsSaved(false),
 
 	_system = g_system;
 	_lastScreenChangeID = _system->getScreenChangeID();
-	_width = _system->getOverlayWidth();
-	_height = _system->getOverlayHeight();
 
 	computeScaleFactor();
 
@@ -588,8 +586,6 @@ bool GuiManager::checkScreenChange() {
 
 void GuiManager::screenChange() {
 	_lastScreenChangeID = _system->getScreenChangeID();
-	_width = _system->getOverlayWidth();
-	_height = _system->getOverlayHeight();
 
 	computeScaleFactor();
 

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -133,9 +133,9 @@ void GuiManager::computeScaleFactor() {
 		_baseHeight = 720;
 	}
 
-	float scaleFactor = (float)h / (float)_baseHeight;
+	_scaleFactor = (float)h / (float)_baseHeight;
 
-	_baseWidth = (int16)((float)w / scaleFactor);
+	_baseWidth = (int16)((float)w / _scaleFactor);
 
 	warning("Setting %d x %d -> %d x %d", w, h, _baseWidth, _baseHeight);
 }

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -119,15 +119,16 @@ GuiManager::~GuiManager() {
 void GuiManager::computeScaleFactor() {
 	int16 w = g_system->getOverlayWidth();
 	int16 h = g_system->getOverlayHeight();
+	uint scale = g_system->getFeatureState(OSystem::kFeatureHiDPI) ? 2 : 1;
 
 	// Hardcoding for now
-	if (h < 240) {	// 320 x 200
+	if (h < 240 * scale) {	// 320 x 200
 		_baseHeight = MIN<int16>(200, h);
-	} else if (h < 400) {	// 320 x 240
+	} else if (h < 400 * scale) {	// 320 x 240
 		_baseHeight = 240;
-	} else if (h < 480) {	// 640 x 400
+	} else if (h < 480 * scale) {	// 640 x 400
 		_baseHeight = 400;
-	} else if (h < 720) {	// 640 x 480
+	} else if (h < 720 * scale) {	// 640 x 480
 		_baseHeight = 480;
 	} else {				// 960 x 720
 		_baseHeight = 720;
@@ -137,7 +138,7 @@ void GuiManager::computeScaleFactor() {
 
 	_baseWidth = (int16)((float)w / _scaleFactor);
 
-	warning("Setting %d x %d -> %d x %d -- %g", w, h, _baseWidth, _baseHeight, _scaleFactor);
+	debug(3, "Setting %d x %d -> %d x %d -- %g", w, h, _baseWidth, _baseHeight, _scaleFactor);
 }
 
 Common::Keymap *GuiManager::getKeymap() const {

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -67,6 +67,8 @@ GuiManager::GuiManager() : _redrawStatus(kRedrawDisabled), _stateIsSaved(false),
 	_width = _system->getOverlayWidth();
 	_height = _system->getOverlayHeight();
 
+	computeScaleFactor();
+
 	_launched = false;
 
 	_useRTL = false;
@@ -114,6 +116,30 @@ GuiManager::GuiManager() : _redrawStatus(kRedrawDisabled), _stateIsSaved(false),
 
 GuiManager::~GuiManager() {
 	delete _theme;
+}
+
+void GuiManager::computeScaleFactor() {
+	int16 w = g_system->getOverlayWidth();
+	int16 h = g_system->getOverlayHeight();
+
+	// Hardcoding for now
+	if (h < 240) {	// 320 x 200
+		_baseHeight = MIN<int16>(200, h);
+	} else if (h < 400) {	// 320 x 240
+		_baseHeight = 240;
+	} else if (h < 480) {	// 640 x 400
+		_baseHeight = 400;
+	} else if (h < 720) {	// 640 x 480
+		_baseHeight = 480;
+	} else {				// 960 x 720
+		_baseHeight = 720;
+	}
+
+	float scaleFactor = (float)h / (float)_baseHeight;
+
+	_baseWidth = (int16)((float)w / scaleFactor);
+
+	warning("Setting %d x %d -> %d x %d", w, h, _baseWidth, _baseHeight);
 }
 
 Common::Keymap *GuiManager::getKeymap() const {
@@ -565,8 +591,10 @@ void GuiManager::screenChange() {
 	_width = _system->getOverlayWidth();
 	_height = _system->getOverlayHeight();
 
+	computeScaleFactor();
+
 	// reinit the whole theme
-	_theme->refresh();
+	_theme->refresh(_baseWidth, _baseHeight);
 
 	// refresh all dialogs
 	for (DialogStack::size_type i = 0; i < _dialogStack.size(); ++i) {

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -638,6 +638,9 @@ void GuiManager::processEvent(const Common::Event &event, Dialog *const activeDi
 		if (mouse.x != _lastMousePosition.x || mouse.y != _lastMousePosition.y) {
 			setLastMousePos(mouse.x, mouse.y);
 		}
+		redraw();
+		_system->updateScreen();
+		g_system->delayMillis(5);
 
 		break;
 		// We don't distinguish between mousebuttons (for now at least)

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -137,7 +137,7 @@ void GuiManager::computeScaleFactor() {
 
 	_baseWidth = (int16)((float)w / _scaleFactor);
 
-	warning("Setting %d x %d -> %d x %d", w, h, _baseWidth, _baseHeight);
+	warning("Setting %d x %d -> %d x %d -- %g", w, h, _baseWidth, _baseHeight, _scaleFactor);
 }
 
 Common::Keymap *GuiManager::getKeymap() const {
@@ -590,7 +590,7 @@ void GuiManager::screenChange() {
 	computeScaleFactor();
 
 	// reinit the whole theme
-	_theme->refresh(_baseWidth, _baseHeight);
+	_theme->refresh(_baseWidth, _baseHeight, _scaleFactor);
 
 	// refresh all dialogs
 	for (DialogStack::size_type i = 0; i < _dialogStack.size(); ++i) {

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -138,6 +138,9 @@ void GuiManager::computeScaleFactor() {
 
 	_baseWidth = (int16)((float)w / _scaleFactor);
 
+	if (_theme)
+		_theme->setBaseResolution(_baseWidth, _baseHeight, _scaleFactor);
+
 	debug(3, "Setting %d x %d -> %d x %d -- %g", w, h, _baseWidth, _baseHeight, _scaleFactor);
 }
 
@@ -215,6 +218,7 @@ bool GuiManager::loadNewTheme(Common::String id, ThemeEngine::GraphicsMode gfx, 
 	// Try to load the new theme
 	newTheme = new ThemeEngine(id, gfx);
 	assert(newTheme);
+	newTheme->setBaseResolution(_baseWidth, _baseHeight, _scaleFactor);
 
 	if (!newTheme->init())
 		return false;
@@ -591,7 +595,7 @@ void GuiManager::screenChange() {
 	computeScaleFactor();
 
 	// reinit the whole theme
-	_theme->refresh(_baseWidth, _baseHeight, _scaleFactor);
+	_theme->refresh();
 
 	// refresh all dialogs
 	for (DialogStack::size_type i = 0; i < _dialogStack.size(); ++i) {

--- a/gui/gui-manager.h
+++ b/gui/gui-manager.h
@@ -91,9 +91,6 @@ public:
 
 	ThemeEval *xmlEval() { return _theme->getEvaluator(); }
 
-	int getWidth() const { return _width; }
-	int getHeight() const { return _height; }
-
 	int getBaseWidth() const { return _baseWidth; }
 	int getBaseHeight() const { return _baseHeight; }
 
@@ -146,7 +143,6 @@ protected:
 //	bool		_needRedraw;
 	RedrawStatus _redrawStatus;
 	int			_lastScreenChangeID;
-	int			_width, _height;
 	int16		_baseWidth, _baseHeight;
 	DialogStack	_dialogStack;
 

--- a/gui/gui-manager.h
+++ b/gui/gui-manager.h
@@ -91,8 +91,9 @@ public:
 
 	ThemeEval *xmlEval() { return _theme->getEvaluator(); }
 
-	int getBaseWidth() const { return _baseWidth; }
-	int getBaseHeight() const { return _baseHeight; }
+	int16 getBaseWidth() const { return _baseWidth; }
+	int16 getBaseHeight() const { return _baseHeight; }
+	float getScaleFactor() const { return _scaleFactor; }
 
 	bool useRTL() const { return _useRTL; }
 	void setLanguageRTL();
@@ -144,6 +145,7 @@ protected:
 	RedrawStatus _redrawStatus;
 	int			_lastScreenChangeID;
 	int16		_baseWidth, _baseHeight;
+	float		_scaleFactor;
 	DialogStack	_dialogStack;
 
 	bool		_stateIsSaved;

--- a/gui/gui-manager.h
+++ b/gui/gui-manager.h
@@ -94,6 +94,9 @@ public:
 	int getWidth() const { return _width; }
 	int getHeight() const { return _height; }
 
+	int getBaseWidth() const { return _baseWidth; }
+	int getBaseHeight() const { return _baseHeight; }
+
 	bool useRTL() const { return _useRTL; }
 	void setLanguageRTL();
 
@@ -144,6 +147,7 @@ protected:
 	RedrawStatus _redrawStatus;
 	int			_lastScreenChangeID;
 	int			_width, _height;
+	int16		_baseWidth, _baseHeight;
 	DialogStack	_dialogStack;
 
 	bool		_stateIsSaved;
@@ -174,6 +178,8 @@ protected:
 		Dialog* parent;
 	};
 	Common::List<GuiObjectTrashItem> _guiObjectTrash;
+
+	void computeScaleFactor();
 
 	void initKeymap();
 	void enableKeymap(bool enabled);

--- a/gui/saveload-dialog.cpp
+++ b/gui/saveload-dialog.cpp
@@ -113,7 +113,7 @@ SaveLoadChooserType getRequestedSaveLoadDialog(const MetaEngine &metaEngine) {
 	// possible to use it.
 	g_gui.checkScreenChange();
 
-	if (g_gui.getWidth() >= 640 && g_gui.getHeight() >= 400
+	if (g_gui.getBaseWidth() >= 640 && g_gui.getBaseHeight() >= 400
 		&& metaEngine.hasFeature(MetaEngine::kSavesSupportMetaInfo)
 		&& metaEngine.hasFeature(MetaEngine::kSavesSupportThumbnail)
 		&& userConfig.equalsIgnoreCase("grid")) {
@@ -342,7 +342,7 @@ void SaveLoadChooserDialog::addChooserButtons() {
 
 	_listButton = createSwitchButton("SaveLoadChooser.ListSwitch", Common::U32String("L"), _("List view"), ThemeEngine::kImageList, kListSwitchCmd);
 	_gridButton = createSwitchButton("SaveLoadChooser.GridSwitch", Common::U32String("G"), _("Grid view"), ThemeEngine::kImageGrid, kGridSwitchCmd);
-	if (!_metaInfoSupport || !_thumbnailSupport || !(g_gui.getWidth() >= 640 && g_gui.getHeight() >= 400)) {
+	if (!_metaInfoSupport || !_thumbnailSupport || !(g_gui.getBaseWidth() >= 640 && g_gui.getBaseHeight() >= 400)) {
 		_gridButton->setEnabled(false);
 		_listButton->setEnabled(false);
 	}

--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -586,16 +586,7 @@ void PicButtonWidget::setGfx(const Graphics::Surface *gfx, int statenum) {
 		return;
 	}
 
-	float scale = g_gui.getScaleFactor();
-
-	if (scale != 1.0f) {
-		Graphics::Surface *tmp = scaleGfx(gfx, gfx->w * scale, gfx->h * scale);
-		_gfx[statenum].copyFrom(*tmp);
-		tmp->free();
-		delete tmp;
-	} else {
-		_gfx[statenum].copyFrom(*gfx);
-	}
+	_gfx[statenum].copyFrom(*gfx);
 }
 
 void PicButtonWidget::setGfx(int w, int h, int r, int g, int b, int statenum) {

--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -839,7 +839,22 @@ void GraphicsWidget::setGfx(const Graphics::Surface *gfx) {
 		return;
 	}
 
-	_gfx.copyFrom(*gfx);
+	if (_w != gfx->w || _h != gfx->h) {
+		const Graphics::PixelFormat &requiredFormat = g_gui.theme()->getPixelFormat();
+		Graphics::Surface tmp;
+
+		tmp.create(gfx->w, gfx->h, g_gui.theme()->getPixelFormat());
+		tmp.copyFrom(*gfx);
+		tmp.convertToInPlace(requiredFormat);
+
+		Graphics::Surface *tmp2 = tmp.scale(_w, _h, false);
+		_gfx.copyFrom(*tmp2);
+		tmp2->free();
+		delete tmp2;
+		tmp.free();
+	} else {
+		_gfx.copyFrom(*gfx);
+	}
 }
 
 void GraphicsWidget::setGfx(int w, int h, int r, int g, int b) {

--- a/gui/widget.cpp
+++ b/gui/widget.cpp
@@ -541,6 +541,20 @@ void DropdownButtonWidget::drawWidget() {
 
 #pragma mark -
 
+Graphics::Surface *scaleGfx(const Graphics::Surface *gfx, int w, int h) {
+	const Graphics::PixelFormat &requiredFormat = g_gui.theme()->getPixelFormat();
+	Graphics::Surface tmp;
+
+	tmp.create(gfx->w, gfx->h, g_gui.theme()->getPixelFormat());
+	tmp.copyFrom(*gfx);
+	tmp.convertToInPlace(requiredFormat);
+
+	Graphics::Surface *tmp2 = tmp.scale(w, h, false);
+	tmp.free();
+
+	return tmp2;
+}
+
 PicButtonWidget::PicButtonWidget(GuiObject *boss, int x, int y, int w, int h, const Common::U32String &tooltip, uint32 cmd, uint8 hotkey)
 	: ButtonWidget(boss, x, y, w, h, Common::U32String(""), tooltip, cmd, hotkey),
 	  _alpha(255), _transparency(false), _showButton(true) {
@@ -572,7 +586,16 @@ void PicButtonWidget::setGfx(const Graphics::Surface *gfx, int statenum) {
 		return;
 	}
 
-	_gfx[statenum].copyFrom(*gfx);
+	float scale = g_gui.getScaleFactor();
+
+	if (scale != 1.0f) {
+		Graphics::Surface *tmp = scaleGfx(gfx, gfx->w * scale, gfx->h * scale);
+		_gfx[statenum].copyFrom(*tmp);
+		tmp->free();
+		delete tmp;
+	} else {
+		_gfx[statenum].copyFrom(*gfx);
+	}
 }
 
 void PicButtonWidget::setGfx(int w, int h, int r, int g, int b, int statenum) {
@@ -840,18 +863,10 @@ void GraphicsWidget::setGfx(const Graphics::Surface *gfx) {
 	}
 
 	if (_w != gfx->w || _h != gfx->h) {
-		const Graphics::PixelFormat &requiredFormat = g_gui.theme()->getPixelFormat();
-		Graphics::Surface tmp;
-
-		tmp.create(gfx->w, gfx->h, g_gui.theme()->getPixelFormat());
-		tmp.copyFrom(*gfx);
-		tmp.convertToInPlace(requiredFormat);
-
-		Graphics::Surface *tmp2 = tmp.scale(_w, _h, false);
-		_gfx.copyFrom(*tmp2);
-		tmp2->free();
-		delete tmp2;
-		tmp.free();
+		Graphics::Surface *tmp = scaleGfx(gfx, _w, _h);
+		_gfx.copyFrom(*tmp);
+		tmp->free();
+		delete tmp;
 	} else {
 		_gfx.copyFrom(*gfx);
 	}


### PR DESCRIPTION
This patch resolves the issues with lagging mouse cursor movement in the GUI when using the OpenGL renderer, especially on Win32.

The call to `g_system->delayMillis(5)` is meant to prevent excessive CPU load and GUI locking and should help to reduce the additional CPU load especially on slower systems.

It's not exactly tied to the changes your branch at all, but I don't want to introduce merging issues on your end :-)