### PR TITLE
VIDEO: Adapt subtitles overlay to text size

### DIFF
--- a/video/subtitles.h
+++ b/video/subtitles.h
@@ -67,6 +67,7 @@ public:
 	void setFont(const char *fontname, int height = 18);
 	void setBBox(const Common::Rect bbox);
 	void setColor(byte r, byte g, byte b);
+	void setPadding(uint16 horizontal, uint16 vertical);
 	void drawSubtitle(uint32 timestamp, bool force = false);
 
 private:
@@ -85,6 +86,8 @@ private:
 	uint32 _color;
 	uint32 _blackColor;
 	uint32 _transparentColor;
+	uint16 _hPad;
+	uint16 _vPad;
 };
 
 } // End of namespace Video


### PR DESCRIPTION
Following https://github.com/scummvm/scummvm/pull/4186
Adapts the overlay size dynamically to text size, due to some backends (e.g. SDL Surface) don't have support for transparent overlay.
Also adds an option to configure the padding to apply.

Thank you.