### PR TITLE
DIRECTOR: Fix bitmap crash and filmloop scaling bug

### DIFF
--- a/engines/director/castmember/bitmap.cpp
+++ b/engines/director/castmember/bitmap.cpp
@@ -409,6 +409,8 @@ Graphics::MacWidget *BitmapCastMember::createWidget(Common::Rect &bbox, Channel 
 }
 
 Graphics::Surface *BitmapCastMember::getDitherImg() {
+	if (!_picture->_surface.getPixels())
+        return nullptr;
 	Graphics::Surface *dither = nullptr;
 
 	// Convert indexed image to indexed palette

--- a/engines/director/castmember/filmloop.cpp
+++ b/engines/director/castmember/filmloop.cpp
@@ -160,8 +160,8 @@ Common::Array<Channel> *FilmLoopCastMember::getSubChannels(Common::Rect &bbox, u
 
 			debugCN(5, kDebugImages, ", scaled: %d,%d %dx%d", src._startPoint.x, src._startPoint.y, src._width, src._height);
 		} else {
-			src._startPoint.x += bbox.left;
-			src._startPoint.y += bbox.top;
+			src._startPoint.x = (src._startPoint.x - _initialRect.left) + bbox.left;
+			src._startPoint.y = (src._startPoint.y - _initialRect.top) + bbox.top;
 
 			debugCN(5, kDebugImages, ", no scaling");
 		}


### PR DESCRIPTION
This PR fixes 2 bugs: 
- Scaling bug for filmloop channels in filmloop.cpp
- Crash when picture is null in BitmapCastMember::getDitherImg(), by adding guards.
